### PR TITLE
Speed up count next

### DIFF
--- a/tokengrams/__init__.py
+++ b/tokengrams/__init__.py
@@ -1,6 +1,3 @@
-import os
-print(os.getcwd())
-
 from .tokengrams import (
     InMemoryIndex,
     MemmapIndex,


### PR DESCRIPTION
Reduce the time to sample a 2049 token trigram sequence from ~530s to ~40s.

The table is lexicographically sorted so after locating the range where a particular token completion occurs the counts of other tokens can exclude both that range and the range to either the left or the right of it depending on whether the previous token index is lower or higher.