### PR TITLE
Kneser-ney smoothing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +150,12 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -118,6 +190,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indicatif"
@@ -456,6 +534,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +562,7 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
+ "derive_builder",
  "funty",
  "indicatif",
  "memmap2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "tokengrams"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,72 +74,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
-dependencies = [
- "derive_builder_core",
- "syn",
-]
-
-[[package]]
 name = "either"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,12 +84,6 @@ name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "funty"
@@ -190,12 +118,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indicatif"
@@ -534,12 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -562,7 +478,6 @@ version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
- "derive_builder",
  "funty",
  "indicatif",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "1.0.81"
 bincode = "1.3.3"
+derive_builder = "0.20.0"
 funty = "2.0.0"
 indicatif = "0.17.8"
 memmap2 = "0.9.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokengrams"
 description = "Compute n-gram statistics and model language over pre-tokenized text corpora used to train large language models." 
 license = "MIT"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 anyhow = "1.0.81"
 bincode = "1.3.3"
-derive_builder = "0.20.0"
 funty = "2.0.0"
 indicatif = "0.17.8"
 memmap2 = "0.9.4"

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ print(index.batch_count_next(
 print(index.sample(tokenizer.encode("hello world"), n=5, k=10))
 
 # Parallelize over sequence generations
-print(index.batch_sample(tokenizer.encode("hello world"), n=5, k=10, num_samples=20))
+print(index.batch_sample(tokenizer.encode("hello world"), n=5, k=10, n_samples=20))
 
 # Query whether the corpus contains "hello world"
 print(index.contains(tokenizer.encode("hello world")))

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ print(index.batch_count_next(
 print(index.sample(tokenizer.encode("hello world"), n=5, k=10))
 
 # Parallelize over sequence generations
-print(index.batch_sample(tokenizer.encode("hello world"), n=5, k=10, n_samples=20))
+print(index.batch_sample(tokenizer.encode("hello world"), n=5, k=10, num_samples=20))
 
 # Query whether the corpus contains "hello world"
 print(index.contains(tokenizer.encode("hello world")))

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -77,9 +77,9 @@ impl InMemoryIndex {
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kneser_ney_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
+    pub fn kn_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
         self.table
-            .kneser_ney_sample(&query, n, k, vocab)
+            .kn_sample(&query, n, k, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -96,7 +96,7 @@ impl InMemoryIndex {
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kneser_ney_batch_sample(
+    pub fn kn_batch_sample(
         &self,
         query: Vec<u16>,
         n: usize,
@@ -105,12 +105,12 @@ impl InMemoryIndex {
         vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kneser_ney_batch_sample(&query, n, k, n_samples, vocab)
+            .kn_batch_sample(&query, n, k, n_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kneser_ney_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-        self.table.kneser_ney_probs(&query, vocab)
+    pub fn kn_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.kn_probs(&query, vocab)
     }
 
     pub fn is_sorted(&self) -> bool {

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -88,11 +88,11 @@ impl InMemoryIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        n_samples: usize,
+        num_samples: usize,
         vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, n_samples, vocab)
+            .batch_sample(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -101,11 +101,11 @@ impl InMemoryIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        n_samples: usize,
+        num_samples: usize,
         vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kn_batch_sample(&query, n, k, n_samples, vocab)
+            .kn_batch_sample(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -71,19 +71,7 @@ impl InMemoryIndex {
         self.table.batch_count_next(&queries, vocab)
     }
 
-    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
-        self.table
-            .sample(&query, n, k, vocab)
-            .map_err(|error| PyValueError::new_err(error.to_string()))
-    }
-
-    pub fn kn_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
-        self.table
-            .kn_sample(&query, n, k, vocab)
-            .map_err(|error| PyValueError::new_err(error.to_string()))
-    }
-
-    pub fn batch_sample(
+    pub fn sample_unsmoothed(
         &self,
         query: Vec<u16>,
         n: usize,
@@ -92,12 +80,12 @@ impl InMemoryIndex {
         vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, num_samples, vocab)
+            .sample_unsmoothed(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kn_batch_sample(
-        &self,
+    pub fn sample_smoothed(
+        &mut self,
         query: Vec<u16>,
         n: usize,
         k: usize,
@@ -105,13 +93,13 @@ impl InMemoryIndex {
         vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kn_batch_sample(&query, n, k, num_samples, vocab)
+            .sample_smoothed(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kn_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-        self.table.kn_probs(&query, vocab)
-    }
+    // pub fn smoothed_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+    //     self.table.smoothed_probs(&query, vocab)
+    // }
 
     pub fn is_sorted(&self) -> bool {
         self.table.is_sorted()

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -51,6 +51,10 @@ impl InMemoryIndex {
         })
     }
 
+    pub fn is_sorted(&self) -> bool {
+        self.table.is_sorted()
+    }
+
     pub fn contains(&self, query: Vec<u16>) -> bool {
         self.table.contains(&query)
     }
@@ -101,8 +105,12 @@ impl InMemoryIndex {
         self.table.get_smoothed_probs(&query, vocab)
     }
 
-    pub fn is_sorted(&self) -> bool {
-        self.table.is_sorted()
+    pub fn batch_smoothed_probs(&mut self, queries: Vec<Vec<u16>>, vocab: Option<u16>) -> Vec<Vec<f64>> {
+        self.table.batch_get_smoothed_probs(&queries, vocab)
+    }
+
+    pub fn estimate_deltas(&mut self, n: usize) {
+        self.table.estimate_deltas(n);
     }
 
     pub fn save(&self, path: String) -> PyResult<()> {

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -97,9 +97,9 @@ impl InMemoryIndex {
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    // pub fn smoothed_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-    //     self.table.smoothed_probs(&query, vocab)
-    // }
+    pub fn smoothed_probs(&mut self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.get_smoothed_probs(&query, vocab)
+    }
 
     pub fn is_sorted(&self) -> bool {
         self.table.is_sorted()

--- a/src/in_memory_index.rs
+++ b/src/in_memory_index.rs
@@ -71,9 +71,15 @@ impl InMemoryIndex {
         self.table.batch_count_next(&queries, vocab)
     }
 
-    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize) -> Result<Vec<u16>, PyErr> {
+    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
         self.table
-            .sample(&query, n, k)
+            .sample(&query, n, k, vocab)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    pub fn kneser_ney_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
+        self.table
+            .kneser_ney_sample(&query, n, k, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -82,11 +88,29 @@ impl InMemoryIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        num_samples: usize,
+        n_samples: usize,
+        vocab: Option<u16>
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, num_samples)
+            .batch_sample(&query, n, k, n_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    pub fn kneser_ney_batch_sample(
+        &self,
+        query: Vec<u16>,
+        n: usize,
+        k: usize,
+        n_samples: usize,
+        vocab: Option<u16>
+    ) -> Result<Vec<Vec<u16>>, PyErr> {
+        self.table
+            .kneser_ney_batch_sample(&query, n, k, n_samples, vocab)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    pub fn kneser_ney_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.kneser_ney_probs(&query, vocab)
     }
 
     pub fn is_sorted(&self) -> bool {

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -119,11 +119,11 @@ impl MemmapIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        n_samples: usize,
+        num_samples: usize,
         vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, n_samples, vocab)
+            .batch_sample(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -142,11 +142,11 @@ impl MemmapIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        n_samples: usize,
+        num_samples: usize,
         vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kn_batch_sample(&query, n, k, n_samples, vocab)
+            .kn_batch_sample(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -134,9 +134,9 @@ impl MemmapIndex {
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    // pub fn smoothed_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-    //     self.table.smoothed_probs(&query, vocab)
-    // }
+    pub fn smoothed_probs(&mut self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.get_smoothed_probs(&query, vocab)
+    }
 
     pub fn is_sorted(&self) -> bool {
         self.table.is_sorted()

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -127,17 +127,17 @@ impl MemmapIndex {
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kneser_ney_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-        self.table.kneser_ney_probs(&query, vocab)
+    pub fn kn_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.kn_probs(&query, vocab)
     }
 
-    pub fn kneser_ney_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
+    pub fn kn_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
         self.table
-            .kneser_ney_sample(&query, n, k, vocab)
+            .kn_sample(&query, n, k, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kneser_ney_batch_sample(
+    pub fn kn_batch_sample(
         &self,
         query: Vec<u16>,
         n: usize,
@@ -146,7 +146,7 @@ impl MemmapIndex {
         vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kneser_ney_batch_sample(&query, n, k, n_samples, vocab)
+            .kn_batch_sample(&query, n, k, n_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -108,13 +108,7 @@ impl MemmapIndex {
         self.table.batch_count_next(&queries, vocab)
     }
 
-    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
-        self.table
-            .sample(&query, n, k, vocab)
-            .map_err(|error| PyValueError::new_err(error.to_string()))
-    }
-
-    pub fn batch_sample(
+    pub fn sample_unsmoothed(
         &self,
         query: Vec<u16>,
         n: usize,
@@ -123,22 +117,12 @@ impl MemmapIndex {
         vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, num_samples, vocab)
+            .sample_unsmoothed(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
-    pub fn kn_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
-        self.table.kn_probs(&query, vocab)
-    }
-
-    pub fn kn_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
-        self.table
-            .kn_sample(&query, n, k, vocab)
-            .map_err(|error| PyValueError::new_err(error.to_string()))
-    }
-
-    pub fn kn_batch_sample(
-        &self,
+    pub fn sample_smoothed(
+        &mut self,
         query: Vec<u16>,
         n: usize,
         k: usize,
@@ -146,9 +130,13 @@ impl MemmapIndex {
         vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .kn_batch_sample(&query, n, k, num_samples, vocab)
+            .sample_smoothed(&query, n, k, num_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
+
+    // pub fn smoothed_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+    //     self.table.smoothed_probs(&query, vocab)
+    // }
 
     pub fn is_sorted(&self) -> bool {
         self.table.is_sorted()

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -108,9 +108,9 @@ impl MemmapIndex {
         self.table.batch_count_next(&queries, vocab)
     }
 
-    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize) -> Result<Vec<u16>, PyErr> {
+    pub fn sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
         self.table
-            .sample(&query, n, k)
+            .sample(&query, n, k, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 
@@ -119,10 +119,34 @@ impl MemmapIndex {
         query: Vec<u16>,
         n: usize,
         k: usize,
-        num_samples: usize,
+        n_samples: usize,
+        vocab: Option<u16>,
     ) -> Result<Vec<Vec<u16>>, PyErr> {
         self.table
-            .batch_sample(&query, n, k, num_samples)
+            .batch_sample(&query, n, k, n_samples, vocab)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    pub fn kneser_ney_probs(&self, query: Vec<u16>, vocab: Option<u16>) -> Vec<f64> {
+        self.table.kneser_ney_probs(&query, vocab)
+    }
+
+    pub fn kneser_ney_sample(&self, query: Vec<u16>, n: usize, k: usize, vocab: Option<u16>) -> Result<Vec<u16>, PyErr> {
+        self.table
+            .kneser_ney_sample(&query, n, k, vocab)
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    pub fn kneser_ney_batch_sample(
+        &self,
+        query: Vec<u16>,
+        n: usize,
+        k: usize,
+        n_samples: usize,
+        vocab: Option<u16>,
+    ) -> Result<Vec<Vec<u16>>, PyErr> {
+        self.table
+            .kneser_ney_batch_sample(&query, n, k, n_samples, vocab)
             .map_err(|error| PyValueError::new_err(error.to_string()))
     }
 

--- a/src/memmap_index.rs
+++ b/src/memmap_index.rs
@@ -88,6 +88,10 @@ impl MemmapIndex {
         })
     }
 
+    pub fn is_sorted(&self) -> bool {
+        self.table.is_sorted()
+    }
+
     pub fn contains(&self, query: Vec<u16>) -> bool {
         self.table.contains(&query)
     }
@@ -138,7 +142,11 @@ impl MemmapIndex {
         self.table.get_smoothed_probs(&query, vocab)
     }
 
-    pub fn is_sorted(&self) -> bool {
-        self.table.is_sorted()
+    pub fn batch_smoothed_probs(&mut self, queries: Vec<Vec<u16>>, vocab: Option<u16>) -> Vec<Vec<f64>> {
+        self.table.batch_get_smoothed_probs(&queries, vocab)
+    }
+
+    pub fn estimate_deltas(&mut self, n: usize) {
+        self.table.estimate_deltas(n);
     }
 }

--- a/src/table.rs
+++ b/src/table.rs
@@ -102,15 +102,9 @@ where
 
     /// Checks if the suffix table is lexicographically sorted. This is always true for valid suffix tables.
     pub fn is_sorted(&self) -> bool {
-        if self.table.len() > 100_000 {
-            self.table
-                .par_windows(2)
-                .all(|pair| self.text[pair[0] as usize..] <= self.text[pair[1] as usize..])
-        } else {
-            self.table
-                .windows(2)
-                .all(|pair| self.text[pair[0] as usize..] <= self.text[pair[1] as usize..])
-        }
+        self.table
+            .par_windows(2)
+            .all(|pair| self.text[pair[0] as usize..] <= self.text[pair[1] as usize..])
     }
 
     /// Returns the suffix at index `i`.
@@ -466,12 +460,8 @@ where
 
     // For a given n, produce a map from an occurrence count in (1, 2) to the number of unique n-grams with that occurrence count.
     fn count_ngrams(&self, n: usize) -> HashMap<usize, usize> {
-        let mut count_map: HashMap<usize, usize> = [(1, 0), (2, 0)]
-            .iter()
-            .cloned()
-            .collect();
-
-        let query = vec![0; 0];
+        let mut count_map = HashMap::from([(1, 0), (2, 0)]);
+        let query = Vec::new();
         let (range_start, range_end) = self.boundaries(&query);
         self.recurse_count_ngrams(range_start, range_end, 1, &query, n, &mut count_map);
         count_map

--- a/src/table.rs
+++ b/src/table.rs
@@ -256,31 +256,36 @@ where
         search_start: usize,
         search_end: usize,
     ) {
-        if search_start == search_end {
+        if search_start >= search_end {
             return;
         }
 
-        let mut idx = search_start + (search_end - search_start) / 2;
-        let mut suffix = self.suffix(idx);
-        while suffix.eq(query_vec) {
-            idx = idx + (search_end - idx) / 2 + 1;
-            if idx >= search_end {
-                return;
-            }
-            suffix = self.suffix(idx);
+        let mut start = search_start;
+        let mid = (start + search_end) / 2;
+
+        let mut suffix = self.suffix(mid);
+        while start < search_end && suffix.eq(query_vec) {
+            start = mid + 1;
+            let mid = (start + search_end) / 2;
+            suffix = self.suffix(mid);
+        }
+
+        // If all suffixes in the range match the query, return
+        if start == search_end {
+            return;
         }
 
         let token = suffix[query_vec.len()];
         query_vec.push(token);
-        let (start, end) = self.range_boundaries(query_vec, search_start, search_end);
+        let (token_start, token_end) = self.range_boundaries(query_vec, start, search_end);
         query_vec.pop();
-        counts[token as usize] = end - start;
+        counts[token as usize] = token_end - token_start;
 
-        if search_start < start {
-            self.recurse_count_next(counts, query_vec, search_start, start);
+        if start < token_start {
+            self.recurse_count_next(counts, query_vec, start, token_start);
         }
-        if end < search_end {
-            self.recurse_count_next(counts, query_vec, end, search_end);
+        if token_end < search_end {
+            self.recurse_count_next(counts, query_vec, token_end, search_end);
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -206,7 +206,7 @@ fn prop_sample() {
 #[test]
 fn kneser_ney_sample() {
     let mut sa = sais("aabbccabccba");
-    sa.compute_kn_unigram_probs();
+    sa.compute_kn_unigram_probs(Some(100));
     let a = utf16!("a");
 
     let tokens = sa.kneser_ney_sample(a, 3, 10, None).unwrap();
@@ -217,7 +217,7 @@ fn kneser_ney_sample() {
 fn kneser_key_probs_empty_query_exists() {
     let mut sa = sais("aaa");
     // sa.kn_cache = Some(vec![1.0 / vocab as f64; vocab as usize]);
-    sa.compute_kn_unigram_probs();
+    sa.compute_kn_unigram_probs(Some(100));
     let vocab = utf16!("a")[0] + 1;
     let probs = sa.kneser_ney_probs(&[], Some(vocab));
     
@@ -233,7 +233,7 @@ fn kneser_ney_probs_exists() {
     let a = utf16!("a")[0] as usize;
     let c = utf16!("c")[0] as usize;
     
-    sa.compute_kn_unigram_probs();
+    sa.compute_kn_unigram_probs(Some(100));
     let sa = sa;
     // let mut kn_unigram_prob = vec![1e-5; vocab as usize];
     // kn_unigram_prob[a] = 0.9;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -176,6 +176,34 @@ fn sample_smoothed_exists() {
 }
 
 #[test]
+fn sample_smoothed_unigrams_exists() {
+    let mut sa = sais("aabbccabccba");
+    let tokens = &sa.sample_smoothed(utf16!("a"), 1, 10, 10, None).unwrap()[0];
+
+    assert_eq!(tokens.len(), 11);
+}
+
+fn large_index() -> SuffixTable {
+    use rand::{distributions::Alphanumeric, Rng};
+
+    let random_string: String = rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(10_000_000)
+        .map(char::from)
+        .collect();
+    sais(&random_string)
+}
+
+#[test]
+fn benchmark() {
+    let mut sa = large_index();
+    // let _ = sa.sample_unsmoothed(&[], 1, 2049, 100, None);
+    let instant = std::time::Instant::now();
+    let _ = sa.sample_smoothed(&[], 3, 2049, 1024, None);
+    println!("Time elapsed: {:?}", instant.elapsed());
+}
+
+#[test]
 fn prop_sample() {
     fn prop(s: String) -> bool {
         let s = s.encode_utf16().collect::<Vec<_>>();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -202,3 +202,15 @@ fn prop_sample() {
 
     qc(prop as fn(String) -> bool);
 }
+
+#[test]
+fn kneser_ney_sample() {
+    let sa = sais("aaabbabababcbababcbabcbabcccbbab");
+    let a = utf16!("a");
+    let c = utf16!("c");
+    let vocab = c[0] + 1;
+
+    let tokens = sa.kneser_ney_sample(a, 3, 10, Some(vocab)).unwrap();
+    assert_eq!(tokens.len(), 11);
+    assert_eq!(tokens, vec![utf16!("a")[0]; 11]);
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -204,29 +204,28 @@ fn prop_sample() {
 }
 
 #[test]
-fn kneser_ney_sample() {
+fn kn_sample() {
     let mut sa = sais("aabbccabccba");
     sa.compute_kn_unigram_probs(Some(100));
     let a = utf16!("a");
 
-    let tokens = sa.kneser_ney_sample(a, 3, 10, None).unwrap();
+    let tokens = sa.kn_sample(a, 3, 10, None).unwrap();
     assert_eq!(tokens.len(), 11);
 }
 
 #[test]
-fn kneser_key_probs_empty_query_exists() {
+fn kn_probs_empty_query_exists() {
     let mut sa = sais("aaa");
-    // sa.kn_cache = Some(vec![1.0 / vocab as f64; vocab as usize]);
     sa.compute_kn_unigram_probs(Some(100));
     let vocab = utf16!("a")[0] + 1;
-    let probs = sa.kneser_ney_probs(&[], Some(vocab));
+    let probs = sa.kn_probs(&[], Some(vocab));
     
     let residual = (probs.iter().sum::<f64>() - 1.0).abs();
     assert!(residual < 1e-4);
 }
 
 #[test]
-fn kneser_ney_probs_exists() {
+fn kn_probs_exists() {
     let mut sa = sais("aaaaaaaabc");
     let query = vec![utf16!("b")[0]];
     let vocab = utf16!("c")[0] + 1;
@@ -235,11 +234,8 @@ fn kneser_ney_probs_exists() {
     
     sa.compute_kn_unigram_probs(Some(100));
     let sa = sa;
-    // let mut kn_unigram_prob = vec![1e-5; vocab as usize];
-    // kn_unigram_prob[a] = 0.9;
-    // kn_unigram_prob[c] = 0.1;
 
-    let smoothed_probs = sa.kneser_ney_probs(&query, Some(vocab));
+    let smoothed_probs = sa.kn_probs(&query, Some(vocab));
     let bigram_counts = sa.count_next(&query, Some(vocab));
     let unsmoothed_probs = bigram_counts
         .iter()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -183,26 +183,6 @@ fn sample_smoothed_unigrams_exists() {
     assert_eq!(tokens.len(), 11);
 }
 
-fn large_index() -> SuffixTable {
-    use rand::{distributions::Alphanumeric, Rng};
-
-    let random_string: String = rand::thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(10_000_000)
-        .map(char::from)
-        .collect();
-    sais(&random_string)
-}
-
-#[test]
-fn benchmark() {
-    let mut sa = large_index();
-    // let _ = sa.sample_unsmoothed(&[], 1, 2049, 100, None);
-    let instant = std::time::Instant::now();
-    let _ = sa.sample_smoothed(&[], 3, 2049, 1024, None);
-    println!("Time elapsed: {:?}", instant.elapsed());
-}
-
 #[test]
 fn prop_sample() {
     fn prop(s: String) -> bool {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -171,7 +171,6 @@ fn sample_unsmoothed_empty_query_exists() {
 #[test]
 fn sample_smoothed_exists() {
     let mut sa = sais("aabbccabccba");
-    sa.compute_kn_unigram_probs(Some(100));
     let a = utf16!("a");
 
     let tokens = &sa.sample_smoothed(a, 3, 10, 1, None).unwrap()[0];

--- a/tokengrams/tokengrams.pyi
+++ b/tokengrams/tokengrams.pyi
@@ -28,8 +28,8 @@ class InMemoryIndex:
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
     
-    def batch_sample(self, query: list[int], n: int, k: int, n_samples: int) -> list[list[int]]:
-        """Autoregressively sample n_samples of k characters each from conditional distributions based 
+    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
+        """Autoregressively sample num_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
 
@@ -67,8 +67,8 @@ class MemmapIndex:
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
    
-    def batch_sample(self, query: list[int], n: int, k: int, n_samples: int) -> list[list[int]]:
-        """Autoregressively samples n_samples of k characters each from conditional distributions based 
+    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used."""
    

--- a/tokengrams/tokengrams.pyi
+++ b/tokengrams/tokengrams.pyi
@@ -62,12 +62,12 @@ class MemmapIndex:
     def batch_count_next(self, queries: list[list[int]], vocab: int | None) -> list[list[int]]:
         """Count the occurrences of each token that directly follows each sequence in `queries`."""
 
-    def sample(self, query: list[int], n: int, k: int) -> list[int]:
-        """Autoregressively k characters from conditional distributions based 
-        on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
-        (n - 1) characters all available characters are used.""" 
+    def sample_smoothed(self, query: list[int], n: int, k: int, num_samples: int, vocab: int | None) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from Kneser-Ney smoothed conditional 
+        distributions based on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are 
+        fewer than (n - 1) characters all available characters are used."""
    
-    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
+    def sample_unsmoothed(self, query: list[int], n: int, k: int, num_samples: int, vocab: int | None) -> list[list[int]]:
         """Autoregressively samples num_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used."""

--- a/tokengrams/tokengrams.pyi
+++ b/tokengrams/tokengrams.pyi
@@ -8,6 +8,10 @@ class InMemoryIndex:
     def from_token_file(path: str, verbose: bool, token_limit: int | None) -> "InMemoryIndex":
         """Construct a `InMemoryIndex` from a file containing raw little-endian tokens."""
 
+    def is_sorted(self) -> bool:
+        """Check if the index's suffix table is sorted lexicographically. 
+        This is always true for valid indices."""
+
     def contains(self, query: list[int]) -> bool:
         """Check if `query` has nonzero count. Faster than `count(query) > 0`."""
     
@@ -23,19 +27,27 @@ class InMemoryIndex:
     def batch_count_next(self, queries: list[list[int]], vocab: int | None) -> list[list[int]]:
         """Count the occurrences of each token that directly follows each sequence in `queries`."""
 
-    def sample(self, query: list[int], n: int, k: int) -> list[int]:
-        """Autoregressively sample k characters from conditional distributions based 
-        on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
-        (n - 1) characters all available characters are used.""" 
-    
-    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
-        """Autoregressively sample num_samples of k characters each from conditional distributions based 
-        on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
-        (n - 1) characters all available characters are used.""" 
+    def smoothed_probs(self, query: list[int], vocab: int | None) -> list[float]:
+        """Compute interpolated Kneser-Ney smoothed token probability distribution using all previous tokens in the query."""
 
-    def is_sorted(self) -> bool:
-        """Check if the index's suffix table is sorted lexicographically. 
-        This is always true for valid indices."""
+    def batch_smoothed_probs(self, queries: list[list[int]], vocab: int | None) -> list[list[float]]:
+        """Compute interpolated Kneser-Ney smoothed token probability distributions using all previous tokens in each query."""
+
+    def sample_smoothed(self, query: list[int], n: int, k: int, num_samples: int, vocab: int | None) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from Kneser-Ney smoothed conditional 
+        distributions based on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are 
+        fewer than (n - 1) characters all available characters are used."""
+   
+    def sample_unsmoothed(self, query: list[int], n: int, k: int, num_samples: int, vocab: int | None) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from conditional distributions based 
+        on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
+        (n - 1) characters all available characters are used."""
+
+    def estimate_deltas(self, n: int):
+        """Warning: O(k**n) where k is vocabulary size, use with caution.
+        Improve smoothed model quality by replacing the default delta hyperparameters
+        for models of order n and below with improved estimates over the entire index.
+        https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf, page 16."""
 
 class MemmapIndex:
     """An n-gram index backed by a memory-mapped file."""
@@ -46,6 +58,10 @@ class MemmapIndex:
     @staticmethod
     def build(token_file: str, index_file: str, verbose: bool) -> "MemmapIndex":
         """Build a memory-mapped index from a token file."""
+
+    def is_sorted(self) -> bool:
+        """Check if the index's suffix table is sorted lexicographically. 
+        This is always true for valid indices."""
     
     def contains(self, query: list[int]) -> bool:
         """Check if `query` has nonzero count. Faster than `count(query) > 0`."""
@@ -71,7 +87,15 @@ class MemmapIndex:
         """Autoregressively samples num_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used."""
-   
-    def is_sorted(self) -> bool:
-        """Check if the index's suffix table is sorted lexicographically. 
-        This is always true for valid indices."""
+
+    def smoothed_probs(self, query: list[int], vocab: int | None) -> list[float]:
+        """Compute interpolated Kneser-Ney smoothed token probability distribution using all previous tokens in the query."""
+
+    def batch_smoothed_probs(self, queries: list[list[int]], vocab: int | None) -> list[list[float]]:
+        """Compute interpolated Kneser-Ney smoothed token probability distributions using all previous tokens in each query."""
+    
+    def estimate_deltas(self, n: int):
+        """Warning: O(k**n) where k is vocabulary size, use with caution.
+        Improve smoothed model quality by replacing the default delta hyperparameters
+        for models of order n and below with improved estimates over the entire index.
+        https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf, page 16."""

--- a/tokengrams/tokengrams.pyi
+++ b/tokengrams/tokengrams.pyi
@@ -28,8 +28,8 @@ class InMemoryIndex:
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
     
-    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
-        """Autoregressively sample num_samples of k characters each from conditional distributions based 
+    def batch_sample(self, query: list[int], n: int, k: int, n_samples: int) -> list[list[int]]:
+        """Autoregressively sample n_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
 
@@ -67,8 +67,8 @@ class MemmapIndex:
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used.""" 
    
-    def batch_sample(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
-        """Autoregressively samples num_samples of k characters each from conditional distributions based 
+    def batch_sample(self, query: list[int], n: int, k: int, n_samples: int) -> list[list[int]]:
+        """Autoregressively samples n_samples of k characters each from conditional distributions based 
         on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
         (n - 1) characters all available characters are used."""
    


### PR DESCRIPTION
- add kneser-ney smoothed probabilities and sampling
- add cache for re-used kneser-ney values (only yields a 10% speedup for a batched sample call over a 100 million item table but I've already added it 🤷‍♀️)
- all sampling, counting, and probability methods now use a faster divide-and-conquer inspired recursive algorithm
- parallelise table::is_sorted when table is large
- remove unnecessary EOS handling code
- remove unbatched sampling methods to reduce complexity/number of exposed functions