### PR TITLE
Add sharded in-memory index, enable rust-side usage, publish to more targets

### DIFF
--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -43,13 +43,13 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter python${{ matrix.python-version }} --features python
+          args: --release --out dist --interpreter python${{ matrix.python-version }}
           manylinux: auto
       - name: Build universal2 wheel for macOS
         if: matrix.os == 'macos-latest' && matrix.python-version == '3.10'
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --universal2 --out dist --interpreter python${{ matrix.python-version }} --features python
+          args: --release --universal2 --out dist --interpreter python${{ matrix.python-version }}
       - name: Upload wheels
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish-wheel.yml
+++ b/.github/workflows/publish-wheel.yml
@@ -1,49 +1,90 @@
 name: Publish
-
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
 
 jobs:
-  publish:
-    name: Publish for ${{ matrix.target }}
+  build:
+    name: Build wheels for ${{ matrix.os }} - Python ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11']
         include:
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
-          - target: x86_64-apple-darwin
-            os: macos-latest
-          - target: x86_64-pc-windows-msvc
-            os: windows-latest
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          # Add ARM64 builds
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            python-version: '3.10'
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            python-version: '3.10'
 
     runs-on: ${{ matrix.os }}
-    environment: PyPI
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Set up Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
+          target: ${{ matrix.target }}
           override: true
-
-      - name: Publish
-        uses: messense/maturin-action@v1
-        env:
-          MATURIN_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
         with:
-          maturin-version: latest
-          command: publish
-          args: --target ${{ matrix.target }} --username=__token__ --skip-existing
+          target: ${{ matrix.target }}
+          args: --release --out dist --interpreter python${{ matrix.python-version }} --features python
+          manylinux: auto
+      - name: Build universal2 wheel for macOS
+        if: matrix.os == 'macos-latest' && matrix.python-version == '3.10'
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --universal2 --out dist --interpreter python${{ matrix.python-version }} --features python
+      - name: Upload wheels
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  build-sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+      - name: Upload sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, build-sdist]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: dist/
+          skip_existing: true

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           mamba install -c conda-forge numpy pytest hypothesis maturin
           maturin develop
-          maturin build --features python
+          maturin build
           python -m pip install --user ./target/wheels/tokengrams*.whl
           pytest

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,6 @@ jobs:
         run: |
           mamba install -c conda-forge numpy pytest hypothesis maturin
           maturin develop
-          maturin build
+          maturin build --features python
           python -m pip install --user ./target/wheels/tokengrams*.whl
           pytest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ edition = "2021"
 name = "tokengrams"
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = []
+python = ["pyo3/extension-module"]
+
 [dependencies]
 anyhow = "1.0.81"
 bincode = "1.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ name = "tokengrams"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = []
-python = ["pyo3/extension-module"]
+default = ["pyo3/extension-module"]
+rust = []
 
 [dependencies]
 anyhow = "1.0.81"

--- a/src/bindings/mod.rs
+++ b/src/bindings/mod.rs
@@ -1,3 +1,4 @@
 pub mod in_memory_index;
 pub mod memmap_index;
 pub mod sharded_memmap_index;
+pub mod sharded_in_memory_index;

--- a/src/bindings/sharded_in_memory_index.rs
+++ b/src/bindings/sharded_in_memory_index.rs
@@ -1,0 +1,115 @@
+use crate::sharded_in_memory_index::ShardedInMemoryIndexRs;
+use anyhow::Result;
+use pyo3::prelude::*;
+
+/// Expose suffix table functionality over text corpora too large to fit in memory.
+#[pyclass]
+pub struct ShardedInMemoryIndex {
+    index: Box<dyn ShardedInMemoryIndexTrait + Send + Sync>,
+}
+
+/// This trait is non-generic for PyO3 compatibility. Implementing structs may cast data
+/// to other unsigned integer types.
+pub trait ShardedInMemoryIndexTrait {
+    fn is_sorted(&self) -> bool;
+    fn contains(&self, query: Vec<usize>) -> bool;
+    fn count(&self, query: Vec<usize>) -> usize;
+    fn count_next(&self, query: Vec<usize>) -> Vec<usize>;
+    fn batch_count_next(&self, queries: Vec<Vec<usize>>) -> Vec<Vec<usize>>;
+    fn sample_unsmoothed(
+        &self,
+        query: Vec<usize>,
+        n: usize,
+        k: usize,
+        num_samples: usize,
+    ) -> Result<Vec<Vec<usize>>>;
+    fn sample_smoothed(
+        &mut self,
+        query: Vec<usize>,
+        n: usize,
+        k: usize,
+        num_samples: usize,
+    ) -> Result<Vec<Vec<usize>>>;
+    fn get_smoothed_probs(&mut self, query: Vec<usize>) -> Vec<f64>;
+    fn batch_get_smoothed_probs(&mut self, queries: Vec<Vec<usize>>) -> Vec<Vec<f64>>;
+    fn estimate_deltas(&mut self, n: usize);
+}
+
+#[pymethods]
+impl ShardedInMemoryIndex {
+    #[new]
+    #[pyo3(signature = (paths, vocab=u16::MAX as usize + 1))]
+    pub fn new(_py: Python, paths: Vec<(String, String)>, vocab: usize) -> PyResult<Self> {
+        if vocab <= u16::MAX as usize + 1 {
+            Ok(ShardedInMemoryIndex {
+                index: Box::new(ShardedInMemoryIndexRs::<u16>::new(paths, vocab)?),
+            })
+        } else {
+            Ok(ShardedInMemoryIndex {
+                index: Box::new(ShardedInMemoryIndexRs::<u32>::new(paths, vocab)?),
+            })
+        }
+    }
+
+    pub fn is_sorted(&self) -> bool {
+        self.index.is_sorted()
+    }
+
+    pub fn contains(&self, query: Vec<usize>) -> bool {
+        self.index.contains(query)
+    }
+
+    pub fn count(&self, query: Vec<usize>) -> usize {
+        self.index.count(query)
+    }
+
+    pub fn count_next(&self, query: Vec<usize>) -> Vec<usize> {
+        self.index.count_next(query)
+    }
+
+    pub fn batch_count_next(&self, queries: Vec<Vec<usize>>) -> Vec<Vec<usize>> {
+        self.index.batch_count_next(queries)
+    }
+
+    /// Autoregressively sample num_samples of k characters from an unsmoothed n-gram model."""
+    pub fn sample_unsmoothed(
+        &self,
+        query: Vec<usize>,
+        n: usize,
+        k: usize,
+        num_samples: usize,
+    ) -> Result<Vec<Vec<usize>>> {
+        self.index.sample_unsmoothed(query, n, k, num_samples)
+    }
+
+    /// Returns interpolated Kneser-Ney smoothed token probability distribution using all previous
+    /// tokens in the query.
+    pub fn get_smoothed_probs(&mut self, query: Vec<usize>) -> Vec<f64> {
+        self.index.get_smoothed_probs(query)
+    }
+
+    /// Returns interpolated Kneser-Ney smoothed token probability distribution using all previous
+    /// tokens in the query.
+    pub fn batch_get_smoothed_probs(&mut self, queries: Vec<Vec<usize>>) -> Vec<Vec<f64>> {
+        self.index.batch_get_smoothed_probs(queries)
+    }
+
+    /// Autoregressively sample num_samples of k characters from a Kneser-Ney smoothed n-gram model.
+    pub fn sample_smoothed(
+        &mut self,
+        query: Vec<usize>,
+        n: usize,
+        k: usize,
+        num_samples: usize,
+    ) -> Result<Vec<Vec<usize>>> {
+        self.index.sample_smoothed(query, n, k, num_samples)
+    }
+
+    /// Warning: O(k**n) where k is vocabulary size, use with caution.
+    /// Improve smoothed model quality by replacing the default delta hyperparameters
+    /// for models of order n and below with improved estimates over the entire index.
+    /// <https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf/>, page 16.
+    pub fn estimate_deltas(&mut self, n: usize) {
+        self.index.estimate_deltas(n);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,15 @@ pub mod mmap_slice;
 pub use bindings::in_memory_index::InMemoryIndex;
 pub use bindings::memmap_index::MemmapIndex;
 pub use bindings::sharded_memmap_index::ShardedMemmapIndex;
+pub use bindings::sharded_in_memory_index::ShardedInMemoryIndex;
+pub use sharded_in_memory_index::ShardedInMemoryIndexRs;
+pub use in_memory_index::InMemoryIndexRs;
+pub use sample::Sample;
+
 pub use table::SuffixTable;
 
 /// Python bindings
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 mod bindings;
@@ -13,13 +19,16 @@ mod memmap_index;
 mod par_quicksort;
 mod sample;
 mod sharded_memmap_index;
+mod sharded_in_memory_index;
 mod table;
 mod util;
 
+#[cfg(feature = "python")]
 #[pymodule]
 fn tokengrams(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<InMemoryIndex>()?;
     m.add_class::<MemmapIndex>()?;
     m.add_class::<ShardedMemmapIndex>()?;
+    m.add_class::<ShardedInMemoryIndex>()?;
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ pub use sample::Sample;
 pub use table::SuffixTable;
 
 /// Python bindings
-#[cfg(feature = "python")]
+#[cfg(not(feature = "rust"))]
 use pyo3::prelude::*;
 
 mod bindings;
@@ -23,7 +23,7 @@ mod sharded_in_memory_index;
 mod table;
 mod util;
 
-#[cfg(feature = "python")]
+#[cfg(not(feature = "rust"))]
 #[pymodule]
 fn tokengrams(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<InMemoryIndex>()?;

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -169,7 +169,7 @@ pub trait Sample<T: Unsigned>: Send + Sync {
     /// Warning: O(k**n) where k is vocabulary size, use with caution.
     /// Improve smoothed model quality by replacing the default delta hyperparameters
     /// for models of order n and below with improved estimates over the entire index.
-    /// https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf, page 16."""
+    /// <https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf/>, page 16.
     fn estimate_deltas(&mut self, n: usize) {
         for i in 1..n + 1 {
             if self.get_cache().n_delta.contains_key(&i) {

--- a/tokengrams/__init__.py
+++ b/tokengrams/__init__.py
@@ -2,6 +2,7 @@ from .tokengrams import (
     InMemoryIndex,
     MemmapIndex,
     ShardedMemmapIndex,
+    ShardedInMemoryIndex
 )
 
 from .utils.tokenize_hf_dataset import tokenize_hf_dataset

--- a/tokengrams/tokengrams.pyi
+++ b/tokengrams/tokengrams.pyi
@@ -156,3 +156,48 @@ class ShardedMemmapIndex:
         Improve smoothed model quality by replacing the default delta hyperparameters
         for models of order n and below with improved estimates over the entire index.
         https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf, page 16."""
+
+
+class ShardedInMemoryIndex:
+    """An n-gram index backed by several memory-mapped files."""
+
+    def __init__(self, paths: list[tuple[str, str]], vocab: int = 2**16) -> None:
+        """Load a prebuilt memory-mapped index from a list of pairs of files in form (token_file, index_file)."""
+
+    def is_sorted(self) -> bool:
+        """Check if the index's suffix table is sorted lexicographically. 
+        This is always true for valid indices."""
+    
+    def contains(self, query: list[int]) -> bool:
+        """Check if `query` has nonzero count. Faster than `count(query) > 0`."""
+    
+    def count(self, query: list[int]) -> int:
+        """Count the number of occurrences of `query` in the index."""
+
+    def count_next(self, query: list[int]) -> list[int]:
+        """Count the occurrences of each token directly following `query`."""
+
+    def batch_count_next(self, queries: list[list[int]]) -> list[list[int]]:
+        """Count the occurrences of each token that directly follows each sequence in `queries`."""
+
+    def sample_smoothed(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from Kneser-Ney smoothed conditional 
+        distributions based on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are 
+        fewer than (n - 1) characters all available characters are used."""
+   
+    def sample_unsmoothed(self, query: list[int], n: int, k: int, num_samples: int) -> list[list[int]]:
+        """Autoregressively samples num_samples of k characters each from conditional distributions based 
+        on the previous (n - 1) characters (n-gram prefix) in the sequence. If there are fewer than 
+        (n - 1) characters all available characters are used."""
+
+    def get_smoothed_probs(self, query: list[int]) -> list[float]:
+        """Compute interpolated Kneser-Ney smoothed token probability distribution using all previous tokens in the query."""
+
+    def batch_get_smoothed_probs(self, queries: list[list[int]]) -> list[list[float]]:
+        """Compute interpolated Kneser-Ney smoothed token probability distributions using all previous tokens in each query."""
+    
+    def estimate_deltas(self, n: int):
+        """Warning: O(k**n) where k is vocabulary size, use with caution.
+        Improve smoothed model quality by replacing the default delta hyperparameters
+        for models of order n and below with improved estimates over the entire index.
+        https://people.eecs.berkeley.edu/~klein/cs294-5/chen_goodman.pdf, page 16."""


### PR DESCRIPTION
- Add sharded in-memory index
- Enable PyO3 as a feature to enable rust-side usage, remove unnecessary pyo3 references from the pure rust classes
- Update publish action to include more targets